### PR TITLE
Update sets list to include A2a–A3b

### DIFF
--- a/pokemontcgp_scrapper.py
+++ b/pokemontcgp_scrapper.py
@@ -83,6 +83,7 @@ sets = [
     "A3",  # Celestial Guardians
     "A3a",  # Extradimensional Crisis
     "A3b",  # Eevee Grove
+    "A4",  # Wisdom of Sea and Sky
     "P-A",  # Promo-A
 ]
 
@@ -394,6 +395,5 @@ iterate_all_sets()
 #convert_cards_to_json(start_id, end_id, filename)
 end_time = time.time()
 print(
-    f"Finished downloading cards to {filename}, total time: {
-        end_time - init_time} segundos."
+    f"Finished downloading cards to {filename}, total time: {end_time - init_time} segundos."
 )

--- a/pokemontcgp_scrapper.py
+++ b/pokemontcgp_scrapper.py
@@ -74,7 +74,17 @@ packs = [
     "Palkia pack",
 ]
 
-sets = ["A1", "P-A", "A1a", "A2"]
+sets = [
+    "A1",  # Genetic Apex
+    "A1a",  # Mythical Island
+    "A2",  # Space-Time Smackdown
+    "A2a",  # Triumphant Light
+    "A2b",  # Shining Revelry
+    "A3",  # Celestial Guardians
+    "A3a",  # Extradimensional Crisis
+    "A3b",  # Eevee Grove
+    "P-A",  # Promo-A
+]
 
 
 def map_attack_cost(cost_elements):


### PR DESCRIPTION
This pull request updates the `sets` list in `pokemontcgp_scrapper.py` to include the most recent Pokémon Pocket expansions:

- A2a: Triumphant Light
- A2b: Shining Revelry
- A3: Celestial Guardians
- A3a: Extradimensional Crisis
- A3b: Eevee Grove